### PR TITLE
adds default values for HPA

### DIFF
--- a/charts/marketsummary/values.yaml
+++ b/charts/marketsummary/values.yaml
@@ -15,6 +15,14 @@ service:
   type: ClusterIP
   port: 8080
 
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 2
+  cpu: 80
+  memory: 512Mi
+  requests:
+
 canary:
   enabled: false
 


### PR DESCRIPTION
don't merge yet

when forked, the repo should have the default values for HPA.  lab 3 will add the `hpa.yaml` file that consumes these values.