### PR TITLE
Fix Mongo driver deprecation warnings

### DIFF
--- a/src/repository/index.js
+++ b/src/repository/index.js
@@ -22,12 +22,21 @@ const getConnection = () => {
     return connection;
 };
 
+const configureMongooseForDriverDeprecations = () => {
+    mongoose.set('useNewUrlParser', true);
+    mongoose.set('useFindAndModify', false);
+    mongoose.set('useCreateIndex', true);
+    mongoose.set('useUnifiedTopology', true);
+};
+
 // createConnection returns a promise.
 function createConnection(username, password) {
     const hostname = config.get("database.hostname"),
         port = config.get("database.port"),
         databaseName = config.get("database.databaseName");
     const connectionString = `mongodb://${username}:${password}@${hostname}:${port}/${databaseName}?authSource=admin`;
+
+    configureMongooseForDriverDeprecations();
 
     return mongoose.createConnection(connectionString);
 }


### PR DESCRIPTION
I ran `make local` and noticed a few deprecation warnings coming from the MongoDB driver via Mongoose:

```
[marketsummary] (node:1) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
[marketsummary] (node:1) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
[marketsummary] (node:1) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] marketsummary-mongodb (10.96.197.34:27017) open
[marketsummary] (node:1) DeprecationWarning: Mongoose: `findOneAndUpdate()` and `findOneAndDelete()` without the `useFindAndModify` option set to false are deprecated. See: https://mongoosejs.com/docs/deprecations.html#findandmodify
[marketsummary] Server running on http://0.0.0.0:5555
```

I went through the Mongoose [docs](https://mongoosejs.com/docs/deprecations.html) for the deprecations and added the config. I didn't see anywhere in the code that used `update`, `remove`, or `count`, which would've required additional code changes. After updating, I didn't see any warnings in the logs and was able to curl `/marketsummary` successfully.:

```
[marketsummary] Server running on http://0.0.0.0:5555
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] Waiting for mongo service
[check-mongodb-ready] marketsummary-mongodb (10.100.201.127:27017) open
```